### PR TITLE
Remove unnecessary `sort!` from `Hash#to_query`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -79,7 +79,7 @@ class Hash
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
-    end.compact.sort! * "&"
+    end.compact * "&"
   end
 
   alias_method :to_param, :to_query

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -529,7 +529,7 @@ class HashExtToParamTests < ActiveSupport::TestCase
   end
 
   def test_to_param_orders_by_key_in_ascending_order
-    assert_equal "a=2&b=1&c=0", Hash[*%w(b 1 c 0 a 2)].to_param
+    assert_equal "b=1&c=0&a=2", Hash[*%w(b 1 c 0 a 2)].to_param
   end
 end
 

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -59,7 +59,7 @@ class ToQueryTest < ActiveSupport::TestCase
       a: 1, b: { c: 3, d: {} }
     assert_query_equal "",
       a: { b: { c: {} } }
-    assert_query_equal "b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=&p=12",
+    assert_query_equal "p=12&b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=",
       p: 12, b: { c: false, e: nil, f: "" }
     assert_query_equal "b%5Bc%5D=3&b%5Bf%5D=",
       b: { c: 3, k: {}, f: "" }
@@ -74,7 +74,7 @@ class ToQueryTest < ActiveSupport::TestCase
 
   def test_hash_sorted_lexicographically
     hash = { type: "human", name: "Nakshay" }
-    assert_equal "name=Nakshay&type=human", hash.to_query
+    assert_equal "type=human&name=Nakshay", hash.to_query
   end
 
   private


### PR DESCRIPTION
Per problems seen in #23997. The issue looks like it stems from problems
in the way that Rack parses nested query params (rack/rack#951,
rack/rack#1058), however this `sort!` is unnecessary and removing it
should help sidestep the issue for at least some use cases.